### PR TITLE
Enable use of CR-LF line endings (Windows)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@ RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
     && chmod +x /tmp/wait-for-it.sh
 WORKDIR /tmp
 COPY ./bin/install-wp-tests.sh /tmp/install-wp-tests.sh
-RUN /tmp/install-wp-tests.sh wordpress_test root $WORDPRESS_DB_PASSWORD mysql $WORDPRESS_VERSION
+RUN dos2unix /tmp/install-wp-tests.sh && /tmp/install-wp-tests.sh wordpress_test root $WORDPRESS_DB_PASSWORD mysql $WORDPRESS_VERSION
 COPY ./db-error.php /tmp/wordpress/wp-content/db-error.php
 WORKDIR /wordpress
 COPY composer.json /wordpress
 RUN composer install 
 COPY . /wordpress
-CMD /tmp/wait-for-it.sh mysql:3306 -- bin/install-db.sh wordpress_test root $WORDPRESS_DB_PASSWORD mysql
+CMD /tmp/wait-for-it.sh mysql:3306 -- cp bin/install-db.sh /tmp/install-db.sh && dos2unix /tmp/install-db.sh && /tmp/install-db.sh wordpress_test root $WORDPRESS_DB_PASSWORD mysql


### PR DESCRIPTION
I had my repo checked out on a Windows environment, and was unable to get the tests running after applying dos2unix on the shell scripts