### PR TITLE
Require phpunit dependency only for testing environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "require": {
+    "require-dev": {
         "phpunit/phpunit":"~5.5.0"
     }
 }


### PR DESCRIPTION
The dependencies which are declared in the `require` section of `composer.json` are typically dependencies required for running in 
- `staging`
- `production` 

environments, whereas the dependencies declared in the `require-dev` section are typically dependencies required in 
- `development`
- `testing` 

environments. 

Since `phpunit` is a dependency required only for testing environment, it's more since to load it by using `require-dev` section instead or `require` section.