### PR TITLE
Update Alpine version URL to fix Docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ sudo: required
 
 env:
   - PHP_IMAGE_TAG=7.0-alpine WORDPRESS_VERSION=latest
-  - PHP_IMAGE_TAG=5.6-alpine WORDPRESS_VERSION=latest
   - PHP_IMAGE_TAG=7.0-alpine WORDPRESS_VERSION=4.4
-  - PHP_IMAGE_TAG=5.6-alpine WORDPRESS_VERSION=4.4
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:$PHP_IMAGE_TAG
 ARG WORDPRESS_DB_PASSWORD
 ENV WORDPRESS_DB_PASSWORD=$WORDPRESS_DB_PASSWORD
 ARG WORDPRESS_VERSION
-RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories &&\
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.7/main" >> /etc/apk/repositories &&\
     apk add --update --no-cache subversion mysql mysql-client git bash g++ make autoconf && \
     set -ex; \
     docker-php-ext-install mysqli pdo pdo_mysql pcntl \


### PR DESCRIPTION
🙏 Hey @omerlh, thanks a ton for your [article](https://medium.com/soluto-engineering/testing-wordpress-plugins-can-be-fun-d926a20452b0) & this template. You've saved me some _major_ headaches trying to get unit testing setup for WordPress.

I had to make one small tweak to get the Docker build working, though.

This PR's pretty quick and sweet: simply updates the Alpine download to v3.7 instead of `edge` so that new folks can still get up and running without any errors.

| Before         | After          |
|----------------|----------------|
| ![Old edge version throws error during build](https://user-images.githubusercontent.com/1619485/108094968-5a9d8f00-704d-11eb-932e-4fa7c34cb20f.png) | ![Updated v3.7 builds successfully](https://user-images.githubusercontent.com/1619485/108094970-5a9d8f00-704d-11eb-828c-e78f59aa7230.png) |

Thanks again!